### PR TITLE
fix：使用openai api时候Retriever.faiss_index,Retriever.faiss_use_gpu报错

### DIFF
--- a/servers/retriever/src/retriever.py
+++ b/servers/retriever/src/retriever.py
@@ -22,6 +22,9 @@ retriever_app = Flask(__name__)
 
 class Retriever:
     def __init__(self, mcp_inst: UltraRAG_MCP_Server):
+        self.faiss_use_gpu = False
+        self.faiss_index = None
+
         mcp_inst.tool(
             self.retriever_init,
             output="retriever_path,corpus_path,index_path,faiss_use_gpu,infinity_kwargs,cuda_devices->None",
@@ -112,7 +115,6 @@ class Retriever:
         with jsonlines.open(corpus_path, mode="r") as reader:
             self.contents = [item["contents"] for item in reader]
 
-        self.faiss_index = None
         if index_path is not None and os.path.exists(index_path):
             cpu_index = faiss.read_index(index_path)
 


### PR DESCRIPTION
pipeline使用如下配置时
```yaml
- retriever.retriever_init_openai
- retriever.retriever_embed_openai
- retriever.retriever_index
```
由于retriever_init_openai 未初始化faiss_index和faiss_use_gpu。会触发报错
```shell
                             │ ❱ 298 │   │   if self.faiss_use_gpu:                                                                                                                                                │                    
                             │   299 │   │   │   co = faiss.GpuMultipleClonerOptions()                                                                                                                             │                    
                             │   300 │   │   │   co.shard = True                                                                                                                                                   │                    
                             │   301 │   │   │   co.useFloat16 = True                                                                                                                                              │                    
                             ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯                    
                             AttributeError: 'Retriever' object has no attribute 'faiss_use_gpu'  
```

```shell
                             │ ❱ 316 │   │   if self.faiss_index is None:                                                                                                                                          │                    
                             │   317 │   │   │   self.faiss_index = index                                                                                                                                          │                    
                             │   318 │   │                                                                                                                                                                         │                    
                             │   319 │   │   app.logger.info("Indexing success")                                                                                                                                   │                    
                             ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯                    
                             AttributeError: 'Retriever' object has no attribute 'faiss_index'  
```