### PR TITLE
修复了chonkie库更新导致的tokenizer_or_token_counter参数名错误

### DIFF
--- a/servers/corpus/src/corpus.py
+++ b/servers/corpus/src/corpus.py
@@ -539,7 +539,7 @@ async def chunk_documents(
             delim = DELIM_DEFAULT
 
         chunker = SentenceChunker(
-            tokenizer_or_token_counter=tokenizer,
+            tokenizer=tokenizer,
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
             min_sentences_per_chunk=min_sentences_per_chunk,
@@ -569,7 +569,7 @@ async def chunk_documents(
             app.logger.error(err_msg)
             raise ToolError(err_msg)
         chunker = RecursiveChunker(
-            tokenizer_or_token_counter=tokenizer,
+            tokenizer=tokenizer,
             chunk_size=chunk_size,
             rules=RecursiveRules(),
             min_characters_per_chunk=min_characters_per_chunk,


### PR DESCRIPTION
貌似是chonkie库的更新导致的，初始化RecursiveChunker的时候，参数应该是
def init(
self,
tokenizer: Union[str, TokenizerProtocol] = "character",
chunk_size: int = 2048,
rules: RecursiveRules = RecursiveRules(),
min_characters_per_chunk: int = 24,
) -> None:

把corpus.py对应的参数名改过来就行了：
chunker = RecursiveChunker(
tokenizer=tokenizer,
chunk_size=chunk_size,
rules=RecursiveRules(),
min_characters_per_chunk=min_characters_per_chunk,
)

否则会导致sentence和recursive分块报错