### PR TITLE
Add LLM cost change analysis to CI

### DIFF
--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@v0.3.0
+      - uses: Jwrede/tokentoll@v0.4.0

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -1,0 +1,17 @@
+name: LLM Cost Analysis
+
+on:
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  cost-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Jwrede/tokentoll@v0.3.0

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@v0.4.0
+      - uses: Jwrede/tokentoll@a4c8ce5f97e751f34498f6503087e5583c02cbbc

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@a4c8ce5f97e751f34498f6503087e5583c02cbbc
+      - uses: Jwrede/tokentoll@cfc9307c2e820de1223fc707ee7e945f6f972379  # v0.5.2

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@ff50a35604b7858d9064cca6354b6229a94f7235  # v0.6.0
+      - uses: Jwrede/tokentoll@753ca4d1150c74169b52a843439049b65e256d2b  # v0.6.1

--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: Jwrede/tokentoll@cfc9307c2e820de1223fc707ee7e945f6f972379  # v0.5.2
+      - uses: Jwrede/tokentoll@ff50a35604b7858d9064cca6354b6229a94f7235  # v0.6.0

--- a/.tokentoll.yml
+++ b/.tokentoll.yml
@@ -1,0 +1,1 @@
+default_model: gpt-4o

--- a/.tokentoll.yml
+++ b/.tokentoll.yml
@@ -1,1 +1,0 @@
-default_model: gpt-4o


### PR DESCRIPTION
## Summary

Add [tokentoll](https://github.com/Jwrede/tokentoll) GitHub Action to analyze LLM API cost changes on pull requests.

When a PR modifies code that makes LLM API calls (model swaps, max_tokens changes, new call sites), tokentoll posts a comment showing the projected cost impact. It stays silent on PRs that don't touch LLM code.

## What it detects

tokentoll uses Python AST analysis (zero runtime dependencies) to find calls to:
- OpenAI (`chat.completions.create`, `responses.create`, `embeddings.create`)
- Anthropic (`messages.create`)
- Google GenAI (`generate_content`)
- LiteLLM (`completion`, `embedding`)
- LangChain (`ChatOpenAI`, `ChatAnthropic`, `init_chat_model`)
- Zhipu AI / GLM (`ZhipuAiClient`, `ZhipuAI`)

## Current scan of this project

## tokentoll Scan Report

| File | Line | SDK | Model | Est. Cost/Call | Monthly |
|------|------|-----|-------|---------------|---------|
| `servers/generation/src/generation.py` | 330 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `servers/generation/src/local_generation.py` | 176 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `servers/generation/src/local_generation.py` | 226 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `servers/retriever/src/retriever.py` | 117 | openai | gpt-4o (default) | $0.04 | $42.21 |

**Total estimated monthly cost: $168.84**

<details>
<summary>Assumptions</summary>

- 1000 calls/month per call site

</details>

*Generated by [tokentoll](https://github.com/Jwrede/tokentoll)*

## How it works

- Runs only on PRs, compares base vs head
- Posts a sticky comment (updates in place, no duplicates)
- Only comments when LLM calls are added, removed, or modified
- First run posts an initial scan (this PR) so you can see the output
- Zero runtime dependencies, ~1s scan time for most projects
- [PyPI](https://pypi.org/project/tokentoll/) | [GitHub](https://github.com/Jwrede/tokentoll)

## Changes

- Adds `.github/workflows/llm-costs.yml` (17 lines)
- No code changes, no new dependencies
