### PR TITLE
fix: multiple bug fixes across core modules and servers

### DIFF
--- a/servers/benchmark/src/benchmark.py
+++ b/servers/benchmark/src/benchmark.py
@@ -83,7 +83,7 @@ def _load_from_local(
     data = _load_data_from_file(path, -1 if is_shuffle else limit)
     ret: Dict[str, List[Any]] = {}
     for alias, original_key in key_map.items():
-        ret[alias] = [item[original_key] for item in data if original_key in item]
+        ret[alias] = [item.get(original_key) for item in data]
 
     if is_shuffle:
         # Check if ret is empty before accessing values

--- a/servers/custom/src/custom.py
+++ b/servers/custom/src/custom.py
@@ -48,7 +48,7 @@ def r1_searcher_query_extract(ans_ls: List[str]) -> Dict[str, List[str]]:
     """
 
     def get_query(text):
-        pattern = re.compile(r"<|begin_of_query|>([^<]*)", re.DOTALL)
+        pattern = re.compile(r"<\|begin_of_query\|>([^<]*)", re.DOTALL)
         matches = pattern.findall(text)
 
         if matches:
@@ -626,11 +626,7 @@ def _surveycpm_to_one_line(string):
         if "content" in string:
             if not string["content"]:
                 return ""
-            return (
-                "[OK] "
-                + string["content"].replace("\n", " ").strip()
-                + _surveycpm_to_one_line(string["content"])
-            )
+            return "[OK] " + string["content"].replace("\n", " ").strip()
         elif "plan" in string:
             return "[PLAN] " + string["plan"].replace("\n", " ").strip()
         else:
@@ -702,7 +698,7 @@ def _surveycpm_print_tasknote_hire(current_survey, last_detail=False):
     try:
         content = _surveycpm_abbr_one_line(current_survey["title"], abbr=False)
         string += f"# Title: {content}\n\n"
-    except:
+    except Exception:
         string += f"# Title: None\n\n"
 
     # sections
@@ -879,7 +875,7 @@ def surveycpm_parse_response(
                     hard_mode=hard_mode,  # You can use hard mode for better performance
                     **kwargs,
                 )
-            except:
+            except Exception:
                 action_is_valid = False
                 action = {}
         else:
@@ -991,7 +987,7 @@ def surveycpm_validate_action(
                     )
                     if "subsections" in section_node:
                         return False
-                except:
+                except Exception:
                     return False
 
             for sec in action["subsections"]:
@@ -1028,7 +1024,7 @@ def surveycpm_validate_action(
                             return False
                 assert action["content"].count("\\cite") <= 12
 
-    except:
+    except Exception:
         return False
 
     return True

--- a/servers/evaluation/src/evaluation.py
+++ b/servers/evaluation/src/evaluation.py
@@ -603,6 +603,8 @@ def evaluate_trec_pvalue(
         key = _process_metric_key(base, k)
         return row[key] if key in row else 0.0
 
+    if metrics is None:
+        metrics = ["recall", "ndcg", "precision", "map", "recip_rank"]
     if ks is None:
         ks = [1, 5, 10, 20, 50, 100]
     n_resamples = int(n_resamples or 10000)

--- a/servers/retriever/src/index_backends/faiss_backend.py
+++ b/servers/retriever/src/index_backends/faiss_backend.py
@@ -206,6 +206,8 @@ class FaissIndexBackend(BaseIndexBackend):
         for doc_ids in indices:
             cur_ret = []
             for doc_id in doc_ids:
+                if doc_id == -1:
+                    continue
                 cur_ret.append(self.contents[doc_id])
             results.append(cur_ret)
         return results

--- a/servers/retriever/src/websearch_backends/exa_backend.py
+++ b/servers/retriever/src/websearch_backends/exa_backend.py
@@ -24,7 +24,14 @@ class ExaWebSearchBackend(BaseWebSearchBackend):
             raise ImportError(err_msg)
 
         api_key = self.config.get("api_key") or os.environ.get("EXA_API_KEY", "")
-        self._client = AsyncExa(api_key=api_key if api_key else "EMPTY")
+        if not api_key:
+            err_msg = (
+                "EXA_API_KEY is not set. "
+                "Please set it via config or the EXA_API_KEY environment variable."
+            )
+            self.logger.error(err_msg)
+            raise ToolError(err_msg)
+        self._client = AsyncExa(api_key=api_key)
 
     async def search(
         self,

--- a/src/ultrarag/client.py
+++ b/src/ultrarag/client.py
@@ -921,12 +921,11 @@ class UltraData:
             pipeline_name: Name of the pipeline
             timestamp: Timestamp string for filename
         """
+        benchmark_name = ""
         benchmark_cfg = self.local_vals.get("benchmark", {})
         if isinstance(benchmark_cfg, dict):
             if "benchmark" in benchmark_cfg and "name" in benchmark_cfg["benchmark"]:
                 benchmark_name = benchmark_cfg["benchmark"]["name"]
-            else:
-                benchmark_name = ""
 
         output_dir = Path("output")
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -1021,17 +1020,15 @@ async def build(config_path: str) -> None:
                     )
                     logger.error(str(e))
                     sys.exit(1)
-            mcp_servers[name] = (
-                {
-                    "command": "npx",
-                    "args": [
-                        "-y",
-                        "mcp-remote",
-                        path,
-                    ],
-                    "env": os.environ.copy(),
-                },
-            )
+            mcp_servers[name] = {
+                "command": "npx",
+                "args": [
+                    "-y",
+                    "mcp-remote",
+                    path,
+                ],
+                "env": os.environ.copy(),
+            }
         else:
             raise ValueError(
                 f"[UltraRAG Error] Unsupported server type for {name}: {path}"
@@ -1266,17 +1263,15 @@ def load_pipeline_context(
                     )
                     logger.error(str(e))
                     sys.exit(1)
-            mcp_cfg["mcpServers"][name] = (
-                {
-                    "command": "npx",
-                    "args": [
-                        "-y",
-                        "mcp-remote",
-                        path,
-                    ],
-                    "env": os.environ.copy(),
-                },
-            )
+            mcp_cfg["mcpServers"][name] = {
+                "command": "npx",
+                "args": [
+                    "-y",
+                    "mcp-remote",
+                    path,
+                ],
+                "env": os.environ.copy(),
+            }
         else:
             raise ValueError(f"Unsupported server type for {name}: {path}")
 
@@ -2208,4 +2203,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/src/ultrarag/server.py
+++ b/src/ultrarag/server.py
@@ -542,9 +542,10 @@ class UltraRAG_MCP_Server(FastMCP):
         if not Path(build_yaml["path"]).exists():
             raise FileNotFoundError(f"Server code not found: {build_yaml['path']}")
 
-        yaml.safe_dump(
-            build_yaml, out_path.open("w"), allow_unicode=True, sort_keys=False
-        )
+        with out_path.open("w") as f:
+            yaml.safe_dump(
+                build_yaml, f, allow_unicode=True, sort_keys=False
+            )
 
     def run(
         self,


### PR DESCRIPTION
## Summary

This PR fixes **11 bugs** across 7 files in the UltraRAG codebase. All fixes are non-breaking — they correct incorrect behavior without changing any public APIs or expected outputs for valid inputs.

### Critical Fixes

1. **Broken regex in `r1_searcher_query_extract`** (`servers/custom/src/custom.py`):
   The pattern `r"<|begin_of_query|>([^<]*)"` treats `|` as regex alternation, so it never matches the literal token `<|begin_of_query|>`. Fixed by escaping: `r"<\|begin_of_query\|>([^<]*)"`.

2. **FAISS search returns wrong passages** (`servers/retriever/src/index_backends/faiss_backend.py`):
   `IndexIDMap.search()` returns `-1` for padding when fewer than `top_k` neighbors exist. The code indexed `self.contents[-1]` silently returning the last document. Added a `-1` filter.

3. **Remote MCP server config stored as tuple** (`src/ultrarag/client.py`):
   A trailing comma `(dict,)` in both `build()` and `load_pipeline_context()` turned the config into a 1-tuple instead of a dict. Consumers expecting a mapping would fail.

### High-Impact Fixes

4. **`UnboundLocalError` for `benchmark_name`** (`src/ultrarag/client.py`):
   When `benchmark_cfg` is not a dict, `benchmark_name` was never assigned but used in `file_path`. Moved the default assignment before the conditional.

5. **`_surveycpm_to_one_line()` content duplication** (`servers/custom/src/custom.py`):
   The function concatenated `string["content"]` with a recursive call on the same content, producing doubled text.

6. **Benchmark ragged lists** (`servers/benchmark/src/benchmark.py`):
   `_load_from_local()` skipped records missing a key, causing parallel lists to differ in length. Changed to `item.get(original_key)` to maintain alignment.

7. **`evaluate_trec_pvalue` crashes when `metrics` is `None`** (`servers/evaluation/src/evaluation.py`):
   Added a default metrics list, consistent with the function's signature allowing `None`.

### Robustness Improvements

8. **Bare `except:` → `except Exception:`** (`servers/custom/src/custom.py`):
   4 bare except clauses were catching `SystemExit`/`KeyboardInterrupt`. Changed to `except Exception:`.

9. **File handle leak in `server.py`** (`src/ultrarag/server.py`):
   `yaml.safe_dump(data, out_path.open("w"))` left the file handle to GC. Wrapped with `with` statement.

10. **`__main__` calls `asyncio.run(main())`** (`src/ultrarag/client.py`):
    `main()` is synchronous (it calls `asyncio.run()` internally). The outer `asyncio.run(None)` would raise `ValueError`.

11. **Exa backend uses `"EMPTY"` API key silently** (`servers/retriever/src/websearch_backends/exa_backend.py`):
    When no API key is configured, the backend silently set `api_key="EMPTY"`, leading to confusing 401 errors. Now raises `ToolError` with a clear message, consistent with the Tavily backend.

## Test Plan

- [ ] All fixes are purely defensive — no behavior change for valid inputs
- [ ] Run existing test suite: `pytest`
- [ ] Verify regex fix captures queries correctly in Search-R1 pipeline
- [ ] Verify FAISS search with small indices (fewer results than top_k)
- [ ] Verify remote MCP server configuration with HTTP/HTTPS endpoints

Made with [Cursor](https://cursor.com)