### PR TITLE
fix: critical bug fixes in query extraction, FAISS search, and MCP config

### DIFF
--- a/servers/custom/src/custom.py
+++ b/servers/custom/src/custom.py
@@ -48,7 +48,7 @@ def r1_searcher_query_extract(ans_ls: List[str]) -> Dict[str, List[str]]:
     """
 
     def get_query(text):
-        pattern = re.compile(r"<|begin_of_query|>([^<]*)", re.DOTALL)
+        pattern = re.compile(r"<\|begin_of_query\|>([^<]*)", re.DOTALL)
         matches = pattern.findall(text)
 
         if matches:
@@ -626,11 +626,7 @@ def _surveycpm_to_one_line(string):
         if "content" in string:
             if not string["content"]:
                 return ""
-            return (
-                "[OK] "
-                + string["content"].replace("\n", " ").strip()
-                + _surveycpm_to_one_line(string["content"])
-            )
+            return "[OK] " + string["content"].replace("\n", " ").strip()
         elif "plan" in string:
             return "[PLAN] " + string["plan"].replace("\n", " ").strip()
         else:

--- a/servers/evaluation/src/evaluation.py
+++ b/servers/evaluation/src/evaluation.py
@@ -603,6 +603,8 @@ def evaluate_trec_pvalue(
         key = _process_metric_key(base, k)
         return row[key] if key in row else 0.0
 
+    if metrics is None:
+        metrics = ["recall", "ndcg", "precision", "map", "recip_rank"]
     if ks is None:
         ks = [1, 5, 10, 20, 50, 100]
     n_resamples = int(n_resamples or 10000)

--- a/servers/retriever/src/index_backends/faiss_backend.py
+++ b/servers/retriever/src/index_backends/faiss_backend.py
@@ -206,6 +206,8 @@ class FaissIndexBackend(BaseIndexBackend):
         for doc_ids in indices:
             cur_ret = []
             for doc_id in doc_ids:
+                if doc_id == -1:
+                    continue
                 cur_ret.append(self.contents[doc_id])
             results.append(cur_ret)
         return results

--- a/servers/retriever/src/websearch_backends/exa_backend.py
+++ b/servers/retriever/src/websearch_backends/exa_backend.py
@@ -24,7 +24,14 @@ class ExaWebSearchBackend(BaseWebSearchBackend):
             raise ImportError(err_msg)
 
         api_key = self.config.get("api_key") or os.environ.get("EXA_API_KEY", "")
-        self._client = AsyncExa(api_key=api_key if api_key else "EMPTY")
+        if not api_key:
+            err_msg = (
+                "EXA_API_KEY is not set. "
+                "Please set it via config or the EXA_API_KEY environment variable."
+            )
+            self.logger.error(err_msg)
+            raise ToolError(err_msg)
+        self._client = AsyncExa(api_key=api_key)
 
     async def search(
         self,

--- a/src/ultrarag/client.py
+++ b/src/ultrarag/client.py
@@ -1021,17 +1021,15 @@ async def build(config_path: str) -> None:
                     )
                     logger.error(str(e))
                     sys.exit(1)
-            mcp_servers[name] = (
-                {
-                    "command": "npx",
-                    "args": [
-                        "-y",
-                        "mcp-remote",
-                        path,
-                    ],
-                    "env": os.environ.copy(),
-                },
-            )
+            mcp_servers[name] = {
+                "command": "npx",
+                "args": [
+                    "-y",
+                    "mcp-remote",
+                    path,
+                ],
+                "env": os.environ.copy(),
+            }
         else:
             raise ValueError(
                 f"[UltraRAG Error] Unsupported server type for {name}: {path}"
@@ -1266,17 +1264,15 @@ def load_pipeline_context(
                     )
                     logger.error(str(e))
                     sys.exit(1)
-            mcp_cfg["mcpServers"][name] = (
-                {
-                    "command": "npx",
-                    "args": [
-                        "-y",
-                        "mcp-remote",
-                        path,
-                    ],
-                    "env": os.environ.copy(),
-                },
-            )
+            mcp_cfg["mcpServers"][name] = {
+                "command": "npx",
+                "args": [
+                    "-y",
+                    "mcp-remote",
+                    path,
+                ],
+                "env": os.environ.copy(),
+            }
         else:
             raise ValueError(f"Unsupported server type for {name}: {path}")
 


### PR DESCRIPTION
## Summary

Six bug fixes for correctness issues that produce **wrong results** or **crash at runtime**. All fixes are non-breaking for valid inputs.

### 1. Broken regex in `r1_searcher_query_extract` (95/100 severity)

The regex pattern `r"<|begin_of_query|>([^<]*)"` treats `|` as **alternation**, so it matches `<` OR `b` OR `e` OR ... instead of the literal token `<|begin_of_query|>`. This completely breaks query extraction in the Search-R1 pipeline.

**Fix:** Escape the pipes → `r"<\|begin_of_query\|>([^<]*)"`.

### 2. Remote MCP server config stored as tuple (90/100)

A trailing comma turns the config into a 1-tuple `(dict,)` instead of a dict:

```python
# Before (bug): creates a tuple
mcp_servers[name] = ({...},)

# After (fix): creates a dict  
mcp_servers[name] = {...}
```

This affects both `build()` and `load_pipeline_context()`, breaking all HTTP/HTTPS remote MCP server configurations.

### 3. FAISS search returns wrong passages (85/100)

`IndexIDMap.search()` returns `-1` for padding when fewer than `top_k` neighbors exist. The code used `self.contents[-1]`, silently returning the **last document** instead of filtering the padding.

### 4. `_surveycpm_to_one_line()` content duplication (78/100)

The function concatenated content with a recursive call on the same content string, producing doubled output text:
```python
# Before: "[OK] content" + "content" (duplicated)
return "[OK] " + string["content"]... + _surveycpm_to_one_line(string["content"])

# After: "[OK] content" (correct)
return "[OK] " + string["content"].replace("\n", " ").strip()
```

### 5. Exa web search uses "EMPTY" API key silently (73/100)

When `EXA_API_KEY` is not configured, the backend silently set `api_key="EMPTY"`, leading to confusing 401 errors at search time. Now raises `ToolError` with a clear message immediately, consistent with the Tavily backend's behavior.

### 6. `evaluate_trec_pvalue` crashes when `metrics` is None (72/100)

The function signature allows `metrics: List[str] | None`, but the loop `for m in metrics` raises `TypeError` when `None` is passed. Added a default metrics list.

## Test Plan

- [ ] Run `pytest` to verify no regressions
- [ ] Verify Search-R1 query extraction with `<|begin_of_query|>` tokens
- [ ] Verify FAISS search with small indices (< top_k documents)
- [ ] Test remote MCP server config with HTTP endpoints
- [ ] Test Exa backend initialization without API key configured

Made with [Cursor](https://cursor.com)