### PR TITLE
chore: defensive improvements for robustness and best practices

### DIFF
--- a/servers/benchmark/src/benchmark.py
+++ b/servers/benchmark/src/benchmark.py
@@ -83,7 +83,7 @@ def _load_from_local(
     data = _load_data_from_file(path, -1 if is_shuffle else limit)
     ret: Dict[str, List[Any]] = {}
     for alias, original_key in key_map.items():
-        ret[alias] = [item[original_key] for item in data if original_key in item]
+        ret[alias] = [item.get(original_key) for item in data]
 
     if is_shuffle:
         # Check if ret is empty before accessing values

--- a/servers/custom/src/custom.py
+++ b/servers/custom/src/custom.py
@@ -702,7 +702,7 @@ def _surveycpm_print_tasknote_hire(current_survey, last_detail=False):
     try:
         content = _surveycpm_abbr_one_line(current_survey["title"], abbr=False)
         string += f"# Title: {content}\n\n"
-    except:
+    except Exception:
         string += f"# Title: None\n\n"
 
     # sections
@@ -879,7 +879,7 @@ def surveycpm_parse_response(
                     hard_mode=hard_mode,  # You can use hard mode for better performance
                     **kwargs,
                 )
-            except:
+            except Exception:
                 action_is_valid = False
                 action = {}
         else:
@@ -991,7 +991,7 @@ def surveycpm_validate_action(
                     )
                     if "subsections" in section_node:
                         return False
-                except:
+                except Exception:
                     return False
 
             for sec in action["subsections"]:
@@ -1028,7 +1028,7 @@ def surveycpm_validate_action(
                             return False
                 assert action["content"].count("\\cite") <= 12
 
-    except:
+    except Exception:
         return False
 
     return True

--- a/src/ultrarag/client.py
+++ b/src/ultrarag/client.py
@@ -921,12 +921,11 @@ class UltraData:
             pipeline_name: Name of the pipeline
             timestamp: Timestamp string for filename
         """
+        benchmark_name = ""
         benchmark_cfg = self.local_vals.get("benchmark", {})
         if isinstance(benchmark_cfg, dict):
             if "benchmark" in benchmark_cfg and "name" in benchmark_cfg["benchmark"]:
                 benchmark_name = benchmark_cfg["benchmark"]["name"]
-            else:
-                benchmark_name = ""
 
         output_dir = Path("output")
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -2208,4 +2207,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/src/ultrarag/server.py
+++ b/src/ultrarag/server.py
@@ -542,9 +542,10 @@ class UltraRAG_MCP_Server(FastMCP):
         if not Path(build_yaml["path"]).exists():
             raise FileNotFoundError(f"Server code not found: {build_yaml['path']}")
 
-        yaml.safe_dump(
-            build_yaml, out_path.open("w"), allow_unicode=True, sort_keys=False
-        )
+        with out_path.open("w") as f:
+            yaml.safe_dump(
+                build_yaml, f, allow_unicode=True, sort_keys=False
+            )
 
     def run(
         self,


### PR DESCRIPTION
## Summary

Five defensive improvements that harden edge-case handling and follow Python best practices. All changes are non-breaking and only affect error paths or rare edge cases.

### 1. Fix potential `UnboundLocalError` in `write_memory_output()`

`benchmark_name` was only assigned inside `if isinstance(benchmark_cfg, dict)`. If `benchmark_cfg` is not a dict, the variable is used uninitialized on the next line. Fixed by initializing `benchmark_name = ""` before the conditional.

### 2. Fix `__main__` entry point

`main()` is a synchronous function that internally calls `asyncio.run()` for async subcommands. The `__main__` block wrapped it in another `asyncio.run(main())`, which would raise `ValueError` after `main()` completes (since it returns `None`, not a coroutine).

### 3. Fix benchmark key mapping producing ragged lists

When some data records are missing a mapped key, the original list comprehension `[item[key] for item in data if key in item]` skips those records entirely. This produces lists of different lengths for different aliases, breaking downstream `zip`-based processing. Changed to `item.get(key)` to maintain alignment (returns `None` for missing keys).

### 4. Replace bare `except:` with `except Exception:`

Four bare `except:` clauses in `custom.py` catch `SystemExit` and `KeyboardInterrupt` in addition to regular exceptions. This can prevent clean process termination. Changed to `except Exception:` per [PEP 8 guidelines](https://peps.python.org/pep-0008/#programming-recommendations).

### 5. Fix file handle leak in `server.py`

`yaml.safe_dump(data, out_path.open("w"))` creates a file handle without a `with` statement. If `safe_dump` raises an exception, the handle may not be closed promptly. Wrapped with `with` statement for proper resource cleanup.

## Test Plan

- [ ] Run `pytest` to verify no regressions
- [ ] These are defensive fixes for edge cases; primary functionality is unaffected

Made with [Cursor](https://cursor.com)