### PR TITLE
docs: remove duplicate Docker startup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ https://github.com/user-attachments/assets/fcf437b7-8b79-42f2-bf4e-e3b7c2a896b9
 
 ## 📦 Installation
 
-We provide two installation methods: local source code installation (recommended using `uv` for package management) and Docker container deployment
+We provide two installation methods: local source code installation (recommended using `uv` for package management) and Docker container deployment.
 
 ### Method 1: Source Code Installation
 
@@ -206,9 +206,6 @@ docker pull hdxin2002/ultrarag:v0.3.0          # Full version (GPU)
 
 # Option B: Build locally
 docker build -t ultrarag:v0.3.0 .
-
-# 3. Start container (port 5050 is automatically mapped)
-docker run -it --gpus all -p 5050:5050 <docker_image_name>
 ```
 
 **Start the Container**


### PR DESCRIPTION
## Summary

- Remove duplicate `docker run` command in the English README: the "Get Code and Images" code block included a step 3 with the container startup command, which was then repeated in the separate "Start the Container" section immediately below. This aligns the English README with the Chinese version (`docs/README_zh.md`), which correctly has the startup instructions only once.
- Add a missing period at the end of the installation section intro sentence.

## Before

The Docker section had the `docker run` command in **two places**:

```
**Get Code and Images**
  # 1. Clone ...
  # 2. Prepare the image ...
  # 3. Start container (port 5050 is automatically mapped)   <-- HERE
  docker run -it --gpus all -p 5050:5050 <docker_image_name>

**Start the Container**
  # Start the container (Port 5050 is mapped by default)     <-- AND HERE
  docker run -it --gpus all -p 5050:5050 <docker_image_name>
```

## After

Step 3 removed from the code block, keeping only the dedicated section below (matching the Chinese README):

```
**Get Code and Images**
  # 1. Clone ...
  # 2. Prepare the image ...

**Start the Container**
  # Start the container (Port 5050 is mapped by default)
  docker run -it --gpus all -p 5050:5050 <docker_image_name>
```

Made with [Cursor](https://cursor.com)