### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,11 +268,11 @@ You can contribute by following the standard process: **Fork this repository →
 
 If you find this repository helpful for your research, please consider giving us a ⭐ to show your support.
 
-<a href="https://star-history.com/#OpenBMB/UltraRAG&Date">
+<a href="https://star-history.dera.page/#OpenBMB/UltraRAG&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=OpenBMB/UltraRAG&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=OpenBMB/UltraRAG&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=OpenBMB/UltraRAG&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=OpenBMB/UltraRAG&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=OpenBMB/UltraRAG&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=OpenBMB/UltraRAG&type=Date" />
  </picture>
 </a>
 

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -268,11 +268,11 @@ Hello, UltraRAG v3!
 
 如果您觉得本项目对您的研究有所帮助，欢迎点亮一颗 ⭐ 来支持我们！
 
-<a href="https://star-history.com/#OpenBMB/UltraRAG&Date">
+<a href="https://star-history.dera.page/#OpenBMB/UltraRAG&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=OpenBMB/UltraRAG&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=OpenBMB/UltraRAG&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=OpenBMB/UltraRAG&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=OpenBMB/UltraRAG&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=OpenBMB/UltraRAG&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=OpenBMB/UltraRAG&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart shown in the README is currently broken because the underlying service stopped working due to the GitHub stargazer API rate limits, so visitors no longer see the chart at all.

This change updates the chart links and images to a working hosting of the star history widget, so the chart renders correctly again in both light and dark themes.