### PR TITLE
feat: add LiteLLM backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,9 +75,16 @@ corpus = [
     "mineru[core]>=3,<4",
 ]
 
+# LiteLLM generation backend: a pure API client, so it is kept separate from the
+# heavy `generation` extra (vllm/torch) — CPU/proxy users can install just this.
+litellm = [
+    "litellm>=1.60,<2.0",
+]
+
 all = [
     "ultrarag[retriever]",
     "ultrarag[generation]",
+    "ultrarag[litellm]",
     "ultrarag[corpus]",
     "ultrarag[evaluation]",
 ]

--- a/servers/generation/parameter.yaml
+++ b/servers/generation/parameter.yaml
@@ -1,6 +1,6 @@
 # servers/generation/parameter.yaml
 
-backend: vllm # options: vllm, openai
+backend: vllm # options: vllm, openai, litellm, hf
 backend_configs:
   vllm:
     model_name_or_path: openbmb/MiniCPM4-8B
@@ -15,6 +15,18 @@ backend_configs:
     concurrency: 8
     retries: 3
     base_delay: 1.0
+  litellm:
+    # Provider-prefixed model routes to 100+ providers via the LiteLLM SDK,
+    # e.g. openai/gpt-4o-mini, anthropic/claude-3-5-sonnet, gemini/gemini-1.5-pro,
+    # bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0, azure/<deployment>.
+    model_name: openai/gpt-4o-mini
+    # api_key: "sk-..."               # optional; falls back to the provider's own
+                                      # env var (OPENAI_API_KEY, ANTHROPIC_API_KEY, ...)
+    # base_url: http://localhost:4000 # optional; e.g. a self-hosted LiteLLM proxy
+    concurrency: 8
+    retries: 3
+    base_delay: 1.0
+    drop_params: true                 # drop provider-unsupported sampling params
   hf:
     model_name_or_path: openbmb/MiniCPM4-8B
     gpu_ids: '2,3'

--- a/servers/generation/src/generation.py
+++ b/servers/generation/src/generation.py
@@ -155,13 +155,13 @@ class Generation:
         extra_params: Optional[Dict[str, Any]] = None,
         backend: str = "vllm",
     ) -> None:
-        """Initialize generation backend (vllm, openai, or hf).
+        """Initialize generation backend (vllm, openai, litellm, or hf).
 
         Args:
             backend_configs: Dictionary of backend-specific configurations
             sampling_params: Sampling parameters for generation
             extra_params: Optional extra parameters (e.g., chat_template_kwargs)
-            backend: Backend name ("vllm", "openai", or "hf")
+            backend: Backend name ("vllm", "openai", "litellm", or "hf")
 
         Raises:
             ImportError: If required dependencies are not installed
@@ -225,6 +225,33 @@ class Generation:
                 app.logger.warning(warn_msg)
 
             self.client = AsyncOpenAI(base_url=base_url, api_key=api_key)
+
+            if extra_params:
+                sampling_params["extra_body"] = extra_params
+            self.sampling_params = sampling_params
+
+            self._max_concurrency = int(cfg.get("concurrency", 1))
+            self._retries = int(cfg.get("retries", 3))
+            self._base_delay = float(cfg.get("base_delay", 1.0))
+
+        elif self.backend == "litellm":
+            self.model_name = cfg.get("model_name")
+            if not self.model_name:
+                error_msg = "model_name is required for litellm backend"
+                app.logger.error(error_msg)
+                raise ValueError(error_msg)
+
+            # api_key / base_url are optional. When unset, LiteLLM falls back to
+            # the provider's own env vars (OPENAI_API_KEY, ANTHROPIC_API_KEY,
+            # AWS creds for Bedrock, etc.), so leave them out of the call kwargs
+            # entirely rather than forwarding empty strings.
+            self.litellm_api_key = cfg.get("api_key") or os.environ.get("LLM_API_KEY")
+            self.litellm_base_url = cfg.get("base_url")
+
+            # Drop per-provider-unsupported sampling params instead of erroring,
+            # so one sampling_params block works across 100+ providers (e.g.
+            # Anthropic/Gemini reject some OpenAI-only kwargs). User can override.
+            self._drop_params = bool(cfg.get("drop_params", True))
 
             if extra_params:
                 sampling_params["extra_body"] = extra_params
@@ -382,6 +409,92 @@ class Generation:
                 asyncio.as_completed(tasks),
                 total=len(tasks),
                 desc="OpenAI Generating: ",
+            ):
+                idx, ans = await coro
+                ret[idx] = ans
+
+        elif self.backend == "litellm":
+            import litellm
+
+            sem = asyncio.Semaphore(self._max_concurrency)
+
+            base_kwargs: Dict[str, Any] = dict(self.sampling_params)
+            base_kwargs["drop_params"] = self._drop_params
+            if self.litellm_api_key:
+                base_kwargs["api_key"] = self.litellm_api_key
+            if self.litellm_base_url:
+                base_kwargs["api_base"] = self.litellm_base_url
+
+            async def call_with_retry(
+                idx,
+                msg,
+                model_name,
+                call_kwargs,
+                retries: int,
+                base_delay: float,
+            ):
+
+                import random
+
+                delay = base_delay
+                for attempt in range(retries):
+                    try:
+                        async with sem:
+                            resp = await litellm.acompletion(
+                                model=model_name,
+                                messages=msg,
+                                **call_kwargs,
+                            )
+                        return idx, (resp.choices[0].message.content or "")
+                    except litellm.AuthenticationError as e:
+                        error_msg = (
+                            f"[{getattr(e, 'status_code', 401)}] Unauthorized: "
+                            f"invalid or missing credentials for model={model_name}."
+                        )
+                        app.logger.error(error_msg)
+                        raise ToolError(error_msg)
+                    except litellm.RateLimitError as e:
+                        warn_msg = f"[429] API Rate limited (idx={idx}, attempt={attempt+1}): {e}"
+                        app.logger.warning(warn_msg)
+                        raise ToolError(warn_msg)
+                    except (
+                        litellm.Timeout,
+                        litellm.APIConnectionError,
+                        litellm.InternalServerError,
+                        litellm.ServiceUnavailableError,
+                    ) as e:
+                        # Transient: log and back off before the next attempt.
+                        warn_msg = f"[transient] Server/network error (idx={idx}, attempt={attempt+1}): {e}"
+                        app.logger.warning(warn_msg)
+                    except Exception as e:
+                        error_msg = f"[Retry {attempt+1}] Failed (idx={idx}): {e}"
+                        app.logger.error(error_msg)
+                        raise ToolError(error_msg)
+
+                    await asyncio.sleep(delay + random.random() * 0.25)
+                    delay *= 2
+
+                return idx, "<error>"
+
+            tasks = [
+                asyncio.create_task(
+                    call_with_retry(
+                        idx,
+                        msg,
+                        self.model_name,
+                        base_kwargs,
+                        retries=getattr(self, "_retries", 3),
+                        base_delay=getattr(self, "_base_delay", 1.0),
+                    )
+                )
+                for idx, msg in enumerate(msg_ls)
+            ]
+            ret = [None] * len(msg_ls)
+
+            for coro in tqdm(
+                asyncio.as_completed(tasks),
+                total=len(tasks),
+                desc="LiteLLM Generating: ",
             ):
                 idx, ans = await coro
                 ret[idx] = ans

--- a/servers/generation/tests/test_litellm_backend.py
+++ b/servers/generation/tests/test_litellm_backend.py
@@ -1,0 +1,114 @@
+"""Unit tests for the LiteLLM generation backend.
+
+`litellm` is an optional extra, so these stub it in ``sys.modules`` before the
+lazy ``import litellm`` inside ``Generation._generate`` runs. No network needed.
+
+Run with the litellm extra installed:
+    uv sync --extra litellm
+    uv run pytest servers/generation/tests/test_litellm_backend.py -v
+"""
+
+import asyncio
+import os
+import sys
+import types
+
+HERE = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(HERE, "..", "src"))
+
+import generation as gen_mod
+
+
+def _stub_litellm(content: str = "ok"):
+    """Install a fake ``litellm`` module and return it (with a .acompletion spy)."""
+    fake = types.ModuleType("litellm")
+    for name in (
+        "AuthenticationError",
+        "RateLimitError",
+        "Timeout",
+        "APIConnectionError",
+        "InternalServerError",
+        "ServiceUnavailableError",
+    ):
+        setattr(fake, name, type(name, (Exception,), {}))
+
+    async def _acompletion(**kwargs):
+        _acompletion.calls.append(kwargs)
+        message = types.SimpleNamespace(content=content)
+        choice = types.SimpleNamespace(message=message)
+        return types.SimpleNamespace(choices=[choice])
+
+    _acompletion.calls = []
+    fake.acompletion = _acompletion
+    sys.modules["litellm"] = fake
+    return fake
+
+
+def _make(cfg):
+    os.environ.pop("LLM_API_KEY", None)
+    g = gen_mod.Generation.__new__(gen_mod.Generation)
+    g.generation_init(
+        backend_configs={"litellm": cfg},
+        sampling_params={"temperature": 0.1, "max_tokens": 8},
+        backend="litellm",
+    )
+    return g
+
+
+def test_dispatch_forwards_model_creds_and_drop_params():
+    fake = _stub_litellm("4")
+    g = _make(
+        {"model_name": "openai/gpt-4o-mini", "api_key": "sk-x", "base_url": "http://proxy"}
+    )
+    out = asyncio.run(g.generate(prompt_ls=["What is 2+2?"]))
+    assert out == {"ans_ls": ["4"]}
+    call = fake.acompletion.calls[0]
+    assert call["model"] == "openai/gpt-4o-mini"
+    assert call["drop_params"] is True
+    assert call["api_key"] == "sk-x"
+    assert call["api_base"] == "http://proxy"
+    assert call["temperature"] == 0.1
+
+
+def test_credentials_omitted_when_blank():
+    # No api_key / base_url -> LiteLLM should fall back to the provider's env vars,
+    # so we must NOT pass empty strings through.
+    fake = _stub_litellm("ok")
+    g = _make({"model_name": "anthropic/claude-3-5-sonnet"})
+    asyncio.run(g.generate(prompt_ls=["hi"]))
+    call = fake.acompletion.calls[0]
+    assert "api_key" not in call
+    assert "api_base" not in call
+    assert call["drop_params"] is True
+
+
+def test_drop_params_opt_out():
+    fake = _stub_litellm("ok")
+    g = _make({"model_name": "openai/gpt-4o-mini", "drop_params": False})
+    asyncio.run(g.generate(prompt_ls=["hi"]))
+    assert fake.acompletion.calls[0]["drop_params"] is False
+
+
+def test_missing_model_name_raises():
+    _stub_litellm("ok")
+    try:
+        _make({"api_key": "sk-x"})
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError when model_name is missing")
+
+
+def test_multiturn_routes_through_litellm():
+    fake = _stub_litellm("Ada")
+    g = _make({"model_name": "gemini/gemini-1.5-pro"})
+    out = asyncio.run(
+        g.multiturn_generate(
+            messages=[
+                {"role": "user", "content": "My name is Ada."},
+                {"role": "assistant", "content": "Hi Ada."},
+                {"role": "user", "content": "What is my name?"},
+            ]
+        )
+    )
+    assert out == {"ans_ls": ["Ada"]}
+    assert fake.acompletion.calls[0]["model"] == "gemini/gemini-1.5-pro"

--- a/servers/retriever/parameter.yaml
+++ b/servers/retriever/parameter.yaml
@@ -5,7 +5,7 @@ corpus_path: data/corpus_example.jsonl
 embedding_path: embedding/embedding.npy
 collection_name: wiki
 
-backend: sentence_transformers # options: infinity, sentence_transformers, openai, bm25
+backend: sentence_transformers # options: infinity, sentence_transformers, openai, litellm, bm25
 backend_configs:
   infinity:
     bettertransformer: false
@@ -26,6 +26,15 @@ backend_configs:
     base_url: "https://api.openai.com/v1"
     api_key: "abc"
     concurrency: 8
+  litellm:
+    # Provider-prefixed embedding model routes to any LiteLLM-supported provider,
+    # e.g. openai/text-embedding-3-small, cohere/embed-english-v3.0,
+    # gemini/text-embedding-004, bedrock/amazon.titan-embed-text-v2:0, azure/<deployment>.
+    model_name: openai/text-embedding-3-small
+    # api_key: "sk-..."               # optional; falls back to the provider's own env var
+    # base_url: http://localhost:4000 # optional; e.g. a self-hosted LiteLLM proxy
+    concurrency: 8
+    drop_params: true
   bm25:
     lang: en # set to zh for Chinese corpora/query
     tokenizer: auto # options: auto, default, jieba, character; auto uses jieba for Chinese

--- a/servers/retriever/src/retriever.py
+++ b/servers/retriever/src/retriever.py
@@ -79,7 +79,7 @@ class Retriever:
         """
         return {k: v for k, v in (d or {}).items() if k not in banned and v is not None}
 
-    async def _openai_embed_texts(
+    async def _api_embed_texts(
         self,
         texts: List[str],
         *,
@@ -90,7 +90,7 @@ class Retriever:
         allow_fallback_zero: bool = False,
         log_prefix: str = "[openai]",
     ) -> List[List[float]]:
-        """Embed texts with OpenAI using controlled concurrency."""
+        """Embed texts with an API backend (openai or litellm) using controlled concurrency."""
         if not texts:
             return []
 
@@ -114,16 +114,39 @@ class Retriever:
         cached_dim: Optional[int] = None
 
         async def _call_batch(batch: List[str]) -> List[List[float]]:
-            resp = await self.model.embeddings.create(
-                model=self.model_name,
-                input=batch,
-            )
-            if len(resp.data) != len(batch):
+            if self.backend == "litellm":
+                import litellm
+
+                call_kwargs: Dict[str, Any] = {
+                    "drop_params": self.litellm_drop_params
+                }
+                if self.litellm_api_key:
+                    call_kwargs["api_key"] = self.litellm_api_key
+                if self.litellm_base_url:
+                    call_kwargs["api_base"] = self.litellm_base_url
+                resp = await litellm.aembedding(
+                    model=self.model_name,
+                    input=batch,
+                    **call_kwargs,
+                )
+                # LiteLLM returns OpenAI-shaped data; items may be dicts or objects.
+                vectors = [
+                    (d["embedding"] if isinstance(d, dict) else d.embedding)
+                    for d in resp.data
+                ]
+            else:
+                resp = await self.model.embeddings.create(
+                    model=self.model_name,
+                    input=batch,
+                )
+                vectors = [d.embedding for d in resp.data]
+
+            if len(vectors) != len(batch):
                 raise RuntimeError(
                     f"{log_prefix} Embedding result size mismatch: "
-                    f"{len(resp.data)} vs {len(batch)}"
+                    f"{len(vectors)} vs {len(batch)}"
                 )
-            return [d.embedding for d in resp.data]
+            return vectors
 
         async def _process_batch(start: int, batch: List[str]) -> None:
             nonlocal cached_dim
@@ -206,7 +229,7 @@ class Retriever:
             corpus_path: Path to corpus file (JSONL format)
             gpu_ids: Comma-separated GPU IDs (e.g., "0,1")
             is_multimodal: Whether to use multimodal (image) embeddings
-            backend: Backend name ("infinity", "sentence_transformers", "openai", or "bm25")
+            backend: Backend name ("infinity", "sentence_transformers", "openai", "litellm", or "bm25")
             index_backend: Index backend name ("faiss" or "milvus")
             index_backend_configs: Dictionary of index backend configurations
             is_demo: Whether to run in demo mode (forces OpenAI + Milvus)
@@ -352,6 +375,36 @@ class Retriever:
                 err_msg = f"[openai] Failed to initialize OpenAI client: {e}"
                 app.logger.error(err_msg)
                 raise RuntimeError(err_msg) from e
+        elif self.backend == "litellm":
+            model_name = self.cfg.get("model_name")
+            if not model_name:
+                err_msg = "[litellm] model_name is required"
+                app.logger.error(err_msg)
+                raise ValueError(err_msg)
+            self.model_name = model_name
+
+            # api_key / base_url are optional. When unset, LiteLLM falls back to the
+            # provider's own env var (OPENAI_API_KEY, COHERE_API_KEY, AWS creds for
+            # Bedrock, ...), so omit them rather than sending empty strings.
+            self.litellm_api_key = self.cfg.get("api_key") or os.environ.get(
+                "RETRIEVER_API_KEY"
+            )
+            self.litellm_base_url = self.cfg.get("base_url")
+            self.litellm_drop_params = bool(self.cfg.get("drop_params", True))
+
+            raw_concurrency = self.cfg.get("concurrency", 1)
+            try:
+                self.openai_concurrency = max(1, int(raw_concurrency or 1))
+            except (TypeError, ValueError):
+                self.openai_concurrency = 1
+                app.logger.warning(
+                    "[litellm] Invalid concurrency=%s, fallback to 1",
+                    raw_concurrency,
+                )
+            app.logger.info(
+                "[litellm] LiteLLM embedding backend initialized (model='%s')",
+                model_name,
+            )
         elif self.backend == "bm25":
             try:
                 import bm25s
@@ -456,7 +509,7 @@ class Retriever:
                 app.logger.warning(f"[retriever] Corpus path not found: {corpus_path}")
 
         self.index_backend: Optional[BaseIndexBackend] = None
-        if self.backend in ["infinity", "sentence_transformers", "openai"]:
+        if self.backend in ["infinity", "sentence_transformers", "openai", "litellm"]:
             index_backend_cfg = self.index_backend_configs.get(
                 self.index_backend_name, {}
             )
@@ -653,19 +706,19 @@ class Retriever:
 
                 embeddings = await asyncio.to_thread(_encode_single)
 
-        elif self.backend == "openai":
+        elif self.backend in ("openai", "litellm"):
             if is_multimodal:
                 err_msg = (
-                    "openai backend does not support image embeddings in this path."
+                    f"{self.backend} backend does not support image embeddings in this path."
                 )
                 app.logger.error(err_msg)
                 raise ValueError(err_msg)
 
-            embeddings = await self._openai_embed_texts(
+            embeddings = await self._api_embed_texts(
                 self.contents,
                 batch_size=self.batch_size,
                 concurrency=getattr(self, "openai_concurrency", 1),
-                desc="[openai] Embedding:",
+                desc=f"[{self.backend}] Embedding:",
                 unit="item",
             )
         else:
@@ -793,7 +846,7 @@ class Retriever:
                 return
 
             app.logger.info(f"[Demo] Embedding {len(texts)} chunks...")
-            all_embeddings = await self._openai_embed_texts(
+            all_embeddings = await self._api_embed_texts(
                 texts,
                 batch_size=self.batch_size,
                 concurrency=getattr(self, "openai_concurrency", 1),
@@ -949,12 +1002,12 @@ class Retriever:
 
                 query_embedding = await asyncio.to_thread(_encode_single)
 
-        elif self.backend == "openai":
-            query_embedding = await self._openai_embed_texts(
+        elif self.backend in ("openai", "litellm"):
+            query_embedding = await self._api_embed_texts(
                 queries,
                 batch_size=self.batch_size,
                 concurrency=getattr(self, "openai_concurrency", 1),
-                desc="[openai] Embedding:",
+                desc=f"[{self.backend}] Embedding:",
                 unit="item",
             )
 

--- a/servers/retriever/tests/test_litellm_embedding.py
+++ b/servers/retriever/tests/test_litellm_embedding.py
@@ -1,0 +1,111 @@
+"""Unit tests for the LiteLLM embedding backend in the retriever server.
+
+`litellm` is an optional extra, so these stub it in ``sys.modules`` before the
+lazy ``import litellm`` inside ``Retriever._api_embed_texts`` runs. No network.
+
+Model names below are arbitrary fixtures — the backend never hardcodes a model,
+it always reads ``model_name`` from config.
+
+    uv sync --extra litellm
+    uv run pytest servers/retriever/tests/test_litellm_embedding.py -v
+"""
+
+import asyncio
+import os
+import sys
+import types
+
+HERE = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(HERE, "..", "src"))
+
+import retriever as r_mod
+
+
+def _stub_litellm(dim: int = 3, as_object: bool = False):
+    """Install a fake litellm whose aembedding echoes deterministic vectors."""
+    fake = types.ModuleType("litellm")
+
+    async def _aembedding(**kwargs):
+        _aembedding.calls.append(kwargs)
+        n = len(kwargs["input"])
+        vecs = [[float(i)] * dim for i in range(n)]
+        if as_object:
+            data = [types.SimpleNamespace(embedding=v) for v in vecs]
+        else:
+            data = [{"embedding": v, "index": i} for i, v in enumerate(vecs)]
+        return types.SimpleNamespace(data=data)
+
+    _aembedding.calls = []
+    fake.aembedding = _aembedding
+    sys.modules["litellm"] = fake
+    return fake
+
+
+def _make(model_name="provider/embed-model", api_key=None, base_url=None):
+    os.environ.pop("RETRIEVER_API_KEY", None)
+    r = r_mod.Retriever.__new__(r_mod.Retriever)
+    r.backend = "litellm"
+    r.model_name = model_name
+    r.litellm_api_key = api_key
+    r.litellm_base_url = base_url
+    r.litellm_drop_params = True
+    r.batch_size = 2
+    r.openai_concurrency = 2
+    return r
+
+
+def _embed(r, texts):
+    return asyncio.run(
+        r._api_embed_texts(texts, batch_size=r.batch_size, concurrency=2, desc="t")
+    )
+
+
+def test_dispatch_and_drop_params_and_creds():
+    fake = _stub_litellm(dim=4)
+    r = _make(model_name="cohere/embed-english-v3.0", api_key="sk-x", base_url="http://proxy")
+    out = _embed(r, ["a", "b", "c"])
+    assert len(out) == 3 and all(len(v) == 4 for v in out)
+    call = fake.aembedding.calls[0]
+    assert call["model"] == "cohere/embed-english-v3.0"
+    assert call["drop_params"] is True
+    assert call["api_key"] == "sk-x"
+    assert call["api_base"] == "http://proxy"
+
+
+def test_credentials_omitted_when_blank():
+    fake = _stub_litellm()
+    r = _make()  # no key / base_url
+    _embed(r, ["a"])
+    call = fake.aembedding.calls[0]
+    assert "api_key" not in call
+    assert "api_base" not in call
+
+
+def test_parses_object_style_response():
+    _stub_litellm(dim=5, as_object=True)
+    r = _make()
+    out = _embed(r, ["a", "b"])
+    assert len(out) == 2 and all(len(v) == 5 for v in out)
+
+
+def test_batching_covers_all_inputs():
+    _stub_litellm(dim=2)
+    r = _make()
+    texts = [f"t{i}" for i in range(5)]  # batch_size=2 -> 3 batches
+    out = _embed(r, texts)
+    assert len(out) == 5
+
+
+def test_size_mismatch_raises():
+    fake = _stub_litellm()
+
+    async def _bad(**kwargs):
+        return types.SimpleNamespace(data=[{"embedding": [0.0]}])  # 1 vec for N inputs
+
+    fake.aembedding = _bad
+    r = _make()
+    try:
+        _embed(r, ["a", "b"])
+    except RuntimeError:
+        return
+    raise AssertionError("expected RuntimeError on size mismatch")

--- a/uv.lock
+++ b/uv.lock
@@ -809,37 +809,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufft = [
-    { name = "nvidia-cufft-cu12" },
+    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufile = [
-    { name = "nvidia-cufile-cu12" },
+    { name = "nvidia-cufile-cu12", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti-cu12" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 curand = [
-    { name = "nvidia-curand-cu12" },
+    { name = "nvidia-curand-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver-cu12" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx-cu12" },
+    { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -1310,6 +1310,36 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/2c/568cf15fd48e4cefd0e605af62da5f5f51db3b012f8441d201d0a1173eb1/fasttext_predict-0.9.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:091938062002fe30d214f6e493a3a1e6180d401212d37eea23c29f4b55f3f347", size = 1281283, upload-time = "2024-11-23T17:23:39.676Z" },
     { url = "https://files.pythonhosted.org/packages/e7/68/0967ec3d5333c23fae1f1bdb851fa896f8f6068ef0ca3a8afee1aa2ee57d/fasttext_predict-0.9.2.4-cp312-cp312-win32.whl", hash = "sha256:981b8d9734623f8f9a8003970f765e14b1d91ee82c59c35e8eba6b76368fa95e", size = 91089, upload-time = "2024-11-23T17:23:41.082Z" },
     { url = "https://files.pythonhosted.org/packages/a7/c5/11c1f50b47f492d562974878ec34b6a0b84699f8b05e1cc3a75c65349784/fasttext_predict-0.9.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:bd3c33971c241577b0767e55d97acfda790f77378f9d5ee7872b6ee4bd63130b", size = 104889, upload-time = "2024-11-23T17:23:42.193Z" },
+]
+
+[[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f3/12481bda4e5b6d3e698fbf525df4443cc7dce746f246b86b6fcb2fba1844/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73946cb950c8caf65127d4e9a325e2b6be0442a224fd51ba3b6ac44e1912ce34", size = 516386, upload-time = "2025-10-19T22:42:40.176Z" },
+    { url = "https://files.pythonhosted.org/packages/59/19/2fc58a1446e4d72b655648eb0879b04e88ed6fa70d474efcf550f640f6ec/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:12ac85024637586a5b69645e7ed986f7535106ed3013640a393a03e461740cb7", size = 264569, upload-time = "2025-10-19T22:25:50.977Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/3c74756e5b02c40cfcc8b1d8b5bac4edbd532b55917a6bcc9113550e99d1/fastuuid-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:05a8dde1f395e0c9b4be515b7a521403d1e8349443e7641761af07c7ad1624b1", size = 254366, upload-time = "2025-10-19T22:29:49.166Z" },
+    { url = "https://files.pythonhosted.org/packages/52/96/d761da3fccfa84f0f353ce6e3eb8b7f76b3aa21fd25e1b00a19f9c80a063/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09378a05020e3e4883dfdab438926f31fea15fd17604908f3d39cbeb22a0b4dc", size = 278978, upload-time = "2025-10-19T22:35:41.306Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/f84c90167cc7765cb82b3ff7808057608b21c14a38531845d933a4637307/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbb0c4b15d66b435d2538f3827f05e44e2baafcc003dd7d8472dc67807ab8fd8", size = 279692, upload-time = "2025-10-19T22:25:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7b/4bacd03897b88c12348e7bd77943bac32ccf80ff98100598fcff74f75f2e/fastuuid-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cd5a7f648d4365b41dbf0e38fe8da4884e57bed4e77c83598e076ac0c93995e7", size = 303384, upload-time = "2025-10-19T22:29:46.578Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a2/584f2c29641df8bd810d00c1f21d408c12e9ad0c0dafdb8b7b29e5ddf787/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c0a94245afae4d7af8c43b3159d5e3934c53f47140be0be624b96acd672ceb73", size = 460921, upload-time = "2025-10-19T22:36:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/c6b77443bb7764c760e211002c8638c0c7cce11cb584927e723215ba1398/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:2b29e23c97e77c3a9514d70ce343571e469098ac7f5a269320a0f0b3e193ab36", size = 480575, upload-time = "2025-10-19T22:28:18.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/87/93f553111b33f9bb83145be12868c3c475bf8ea87c107063d01377cc0e8e/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1e690d48f923c253f28151b3a6b4e335f2b06bf669c68a02665bc150b7839e94", size = 452317, upload-time = "2025-10-19T22:25:32.75Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8c/a04d486ca55b5abb7eaa65b39df8d891b7b1635b22db2163734dc273579a/fastuuid-0.14.0-cp311-cp311-win32.whl", hash = "sha256:a6f46790d59ab38c6aa0e35c681c0484b50dc0acf9e2679c005d61e019313c24", size = 154804, upload-time = "2025-10-19T22:24:15.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b2/2d40bf00820de94b9280366a122cbaa60090c8cf59e89ac3938cf5d75895/fastuuid-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:e150eab56c95dc9e3fefc234a0eedb342fac433dacc273cd4d150a5b0871e1fa", size = 156099, upload-time = "2025-10-19T22:24:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
 ]
 
 [[package]]
@@ -1822,14 +1852,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "9.0.0"
+version = "8.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/72/c600ae4f68c28fc19f9c31b9403053e5dbb8cace2e6842c7b7c3e4d42fe9/importlib_metadata-8.9.0.tar.gz", hash = "sha256:58850626cef4bd2df100378b0f2aea9724a7b92f10770d547725b047078f99ee", size = 56140, upload-time = "2026-03-20T16:56:26.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/f9/97f2ca8bb3ec6e4b1d64f983ebe98b9a192faddff67fac3d6303a537e670/importlib_metadata-8.9.0-py3-none-any.whl", hash = "sha256:e0f761b6ea91ced3b0844c14c9d955224d538105921f8e6754c00f6ca79fba7f", size = 27220, upload-time = "2026-03-20T16:56:25.07Z" },
 ]
 
 [[package]]
@@ -2439,6 +2469,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/60/bc7622aefb2aee1c0b4ba23c1446d3e30225c8770b38d7aedbfb65ca9d5a/lark-1.2.2.tar.gz", hash = "sha256:ca807d0162cd16cef15a8feecb862d7319e7a09bdb13aef927968e45040fed80", size = 252132, upload-time = "2024-08-13T19:49:00.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/00/d90b10b962b4277f5e64a78b6609968859ff86889f5b898c1a778c06ec00/lark-1.2.2-py3-none-any.whl", hash = "sha256:c2276486b02f0f1b90be155f2c8ba4a8e194d42775786db622faccd652d8e80c", size = 111036, upload-time = "2024-08-13T19:48:58.603Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.97.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/08/db78a9f53e5688ad0f9e50d5c3bfe616e445aac120eafcca907f04634e48/litellm-1.97.0.tar.gz", hash = "sha256:6f7ce326a2e5385ef850e0b0768d41f502ec79278860090a838511cea067b067", size = 17762282, upload-time = "2026-08-16T00:05:44.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/d4/a04f8bda468fb25a0a8a392a6922c9ecf6c122ad9bf9e2f69ebd173e1cac/litellm-1.97.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ff401dd5d66f54b9b474f0652c419fb7bf883fbf5ca64c0bc363acdc98b758b5", size = 24235645, upload-time = "2026-08-16T00:05:20.055Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/51/a055bf5df38112f07970937d95416b22379ee84664b739bfe87a8292e098/litellm-1.97.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:2983b40ed5d8b1bcbbfbc0d66fefa21b04db91b87c05dd680ae77cba74e561ef", size = 23893493, upload-time = "2026-08-16T00:05:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/14/28/b1cf429493aec5260ac2737dd82f6200c729fd26b336dc21cf001cfbcd8a/litellm-1.97.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e3a1f70d693716b4e8a8108f0a464b0e2c555e274ddbb8ef89c4c59c80be14ed", size = 24031743, upload-time = "2026-08-16T00:05:27.138Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4a/22c49e8bd068bfdab0daba235cc2d2752d76d855ccb8f6dafe7dabf01ca4/litellm-1.97.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:5b56dce7df44a6a9e6caf5379de2578a8cb82831ceabd3d71cc99b370a1015e7", size = 24397362, upload-time = "2026-08-16T00:05:30.89Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/22/f60558230969ac7d860bd93aff6bf6a69bcd8a3ef4f35eea211174ef4e81/litellm-1.97.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6b360ddc3162c2ed39b64d3f9957a7af70cd9c60cf71f7a4dfa355a0bf05bebc", size = 24107078, upload-time = "2026-08-16T00:05:34.463Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e4/6c74ff4b188d9399a036d41e86c4c616d95ce5fd9d9b3c42646bd02f270e/litellm-1.97.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3c4f1dd45e14127f2303769a7ae79482697823e329ae503513d014ceea4dd704", size = 24493640, upload-time = "2026-08-16T00:05:37.85Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/1475c4ecdf43221ab8ee8d0fcc6b469c26d0d80913d0773e18de81cf18f1/litellm-1.97.0-cp310-abi3-win_amd64.whl", hash = "sha256:dce3377207234fc5c5b275a5e234ba056a5051fd178ae8e9a6aeb5d056f12095", size = 24289278, upload-time = "2026-08-16T00:05:41.441Z" },
 ]
 
 [[package]]
@@ -3200,7 +3260,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.17.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/55/9987152bd99746b6d5d899a3e920f72f565f5adb4835dc44899382482e2c/nvidia_cudnn_cu12-9.17.1.4-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:d18d61bdd596fca0dbe459c129f6eb7a24ed2e6de1d7988b0a37ac63184ee05d", size = 646648394, upload-time = "2025-12-22T16:42:08.8Z" },
@@ -3225,7 +3285,7 @@ name = "nvidia-cufft-cu12"
 version = "11.4.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
@@ -3255,9 +3315,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.5.82"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/99/686ff9bf3a82a531c62b1a5c614476e8dfa24a9d89067aeedf3592ee4538/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2", size = 337869834, upload-time = "2025-06-05T20:06:53.125Z" },
@@ -3269,7 +3329,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.10.65"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/6f/8710fbd17cdd1d0fc3fea7d36d5b65ce1933611c31e1861da330206b253a/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83", size = 366359408, upload-time = "2025-06-05T20:07:42.501Z" },
@@ -4964,7 +5024,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -5000,7 +5060,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -5021,8 +5081,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "jeepney", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -5494,13 +5554,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "fsspec", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "jinja2", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "networkx", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "setuptools", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "sympy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/0d/98b410492609e34a155fa8b121b55c7dca229f39636851c3a9ec20edea21/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7b6a60d48062809f58595509c524b88e6ddec3ebe25833d6462eeab81e5f2ce4", size = 80529712, upload-time = "2026-03-23T18:12:02.608Z" },
@@ -5516,20 +5576,20 @@ resolution-markers = [
     "(python_full_version < '3.12' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform == 'win32')",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform != 'win32'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform != 'win32'" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "nvidia-cudnn-cu12", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cusparselt-cu12", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nccl-cu12", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvshmem-cu12", marker = "sys_platform != 'win32'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "triton", marker = "sys_platform != 'win32'" },
-    { name = "typing-extensions" },
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "fsspec", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "jinja2", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "networkx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
+    { name = "setuptools", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "sympy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu129/torch-2.11.0%2Bcu129-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:ae3cf4a1082fbfbed7409dcfe9f767d9124da4730e2bb8857f1656fa490d8d69", upload-time = "2026-04-27T18:38:46Z" },
@@ -5749,6 +5809,7 @@ all = [
     { name = "faiss-gpu-cu12" },
     { name = "fastapi" },
     { name = "infinity-emb" },
+    { name = "litellm" },
     { name = "mineru", extra = ["core"] },
     { name = "numba" },
     { name = "openai" },
@@ -5779,6 +5840,9 @@ generation = [
     { name = "transformers" },
     { name = "vllm" },
     { name = "xgrammar" },
+]
+litellm = [
+    { name = "litellm" },
 ]
 retriever = [
     { name = "bm25s" },
@@ -5821,6 +5885,7 @@ requires-dist = [
     { name = "infinity-emb", marker = "extra == 'retriever'" },
     { name = "jieba" },
     { name = "jinja2" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.60,<2.0" },
     { name = "mcp" },
     { name = "mineru", extras = ["core"], marker = "extra == 'corpus'", specifier = ">=3,<4" },
     { name = "numba", marker = "extra == 'retriever'" },
@@ -5856,12 +5921,13 @@ requires-dist = [
     { name = "ultrarag", extras = ["corpus"], marker = "extra == 'all'" },
     { name = "ultrarag", extras = ["evaluation"], marker = "extra == 'all'" },
     { name = "ultrarag", extras = ["generation"], marker = "extra == 'all'" },
+    { name = "ultrarag", extras = ["litellm"], marker = "extra == 'all'" },
     { name = "ultrarag", extras = ["retriever"], marker = "extra == 'all'" },
     { name = "uvicorn", marker = "extra == 'retriever'" },
     { name = "vllm", marker = "extra == 'generation'", specifier = "==0.22.1", index = "https://wheels.vllm.ai/0.22.1/cu129" },
     { name = "xgrammar", marker = "extra == 'generation'", specifier = "<0.2.4" },
 ]
-provides-extras = ["retriever", "generation", "evaluation", "corpus", "all"]
+provides-extras = ["retriever", "generation", "evaluation", "corpus", "litellm", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
* Adds **LiteLLM** as a first class backend in **two** servers: a generation backend in `servers/generation` (alongside `vllm`/`openai`/`hf`) and an embedding backend in `servers/retriever` (alongside `infinity`/`sentence_transformers`/`openai`/`bm25`).
* One `backend: litellm` config gives access to **100+ LLM providers** (OpenAI, Anthropic, Gemini, Bedrock, Vertex, Azure, Groq, Mistral, Cohere, DeepSeek, local proxies, and more) through a single unified interface for both chat completion and embeddings, with no separate proxy to run.
* Additive only. Existing backends are untouched, and `litellm` is an optional extra so the base install is unaffected. No model is hardcoded anywhere; the provider and model always come from config (`model_name`).


## Changes

**Generation backend** (`servers/generation`)
* `src/generation.py`: new `litellm` branch in `generation_init` (config parsing) and `_generate` (async dispatch via `litellm.acompletion`, concurrency plus retry mirroring the `openai` backend). `litellm` is lazy imported inside the branch so it stays optional.
* `parameter.yaml`: documented `litellm` backend config block (`model_name`, optional `api_key`/`base_url`, `concurrency`, `retries`, `base_delay`, `drop_params`).
* `tests/test_litellm_backend.py`: unit tests

**Embedding backend** (`servers/retriever`)
* `src/retriever.py`: new `litellm` embedding branch in `retriever_init`; generalized the shared embed helper (`_openai_embed_texts` to `_api_embed_texts`) so its batching, concurrency, and fallback logic is reused, with a `litellm.aembedding` dispatch path (handles both dict shaped and object shaped response items). Extended the 3 embed dispatch points (index init, corpus embed, query embed) to accept `litellm`.
* `parameter.yaml`: documented `litellm` embedding config block.
* `tests/test_litellm_embedding.py`: unit tests (stub `litellm.aembedding`, no network).

**Packaging**
* `pyproject.toml`: new optional extra `litellm = ["litellm>=1.60,<2.0"]`, added to the `all` extra. Kept **separate from the heavy `generation` extra** (vllm and torch) since the LiteLLM backends are pure API clients, so CPU and proxy users install just `ultrarag[litellm]` for both chat and embeddings.
* `uv.lock`: regenerated with `uv lock` (adds only `litellm`, `fastuuid`; `uv lock --check` passes).


## Tests

**1. Unit tests**, 10 passing
```
servers/generation/tests/test_litellm_backend.py ..... (5 passed)   # generation dispatch, drop_params, creds, multiturn
servers/retriever/tests/test_litellm_embedding.py ..... (5 passed)  # embedding dispatch, drop_params, creds, batching, response parsing
```

**2. Live end to end (generation)** through the real `Generation.generate` and `multiturn_generate` code path (backend=`litellm`), across three providers to prove routing plus cross provider `drop_params` safety:
```
== azure/gpt-4o-mini (batched, concurrency path) ==
{'ans_ls': ['4', 'Paris.']}
== gemini (cross-provider, drop_params) ==
{'ans_ls': ['OK']}
== multi-turn ==
{'ans_ls': ['Ada']}
```
This exercises the full chain: `generate` to `_generate` (litellm branch) to `litellm.acompletion` to provider to response parsed back into `ans_ls`. The embedding backend uses the identical credential and dispatch pattern (`litellm.aembedding`), verified by the unit tests above.

**3. Dependency lock**: `uv lock --check` passes; the CUDA 13 guard in CI stays clean; only `litellm` plus `fastuuid` are added to the graph.

**4. Lint**: `ruff check` is clean on the new test file; the backend change matches the file's existing typing and style conventions.

## Example usage
`servers/generation/parameter.yaml`:
```yaml
backend: litellm
backend_configs:
  litellm:
    model_name: anthropic/claude-3-5-sonnet   # or openai/gpt-4o-mini, gemini/gemini-1.5-pro, bedrock/...
    # api_key: sk-...            # optional; falls back to the provider's own env var
    # base_url: http://localhost:4000   # optional; e.g. a self-hosted LiteLLM proxy
    concurrency: 8
    retries: 3
    base_delay: 1.0
    drop_params: true
```
`servers/retriever/parameter.yaml` (embeddings):
```yaml
backend: litellm
backend_configs:
  litellm:
    model_name: cohere/embed-english-v3.0   # or openai/text-embedding-3-small, gemini/text-embedding-004, bedrock/...
    # api_key / base_url optional (same fall-through as generation)
    concurrency: 8
    drop_params: true
```
Then run any pipeline that uses the `generation` or `retriever` server unchanged.

