### PR TITLE
fix: keep legacy knowledge bases private by default

### DIFF
--- a/ui/backend/kb_visibility_store.py
+++ b/ui/backend/kb_visibility_store.py
@@ -135,14 +135,14 @@ class SQLiteKbVisibilityStore:
                     f"""
                     INSERT INTO {TABLE_NAME}
                     (collection_name, owner_user_id, is_public, visible_users_json, created_at, updated_at)
-                    VALUES (?, ?, 1, '[]', ?, ?)
+                    VALUES (?, ?, 0, '[]', ?, ?)
                     """,
                     (normalized_collection, normalized_owner, now, now),
                 )
                 conn.commit()
                 existing = self._fetch_row(conn, normalized_collection)
         if not existing:
-            raise RuntimeError("failed to ensure legacy public visibility mapping")
+            raise RuntimeError("failed to ensure legacy private visibility mapping")
         return self._row_to_dict(existing)
 
     def bootstrap_legacy_public(
@@ -175,7 +175,7 @@ class SQLiteKbVisibilityStore:
                 f"""
                 INSERT INTO {TABLE_NAME}
                 (collection_name, owner_user_id, is_public, visible_users_json, created_at, updated_at)
-                VALUES (?, ?, 1, '[]', ?, ?)
+                VALUES (?, ?, 0, '[]', ?, ?)
                 """,
                 [(name, normalized_owner, now, now) for name in missing],
             )


### PR DESCRIPTION
## Related issue

Fixes #456 (the legacy knowledge-base visibility issue).

## Background

Collections without a visibility row were bootstrapped as public, exposing collections created through indexing paths that did not write an explicit ACL.

## Changes

- Keep legacy visibility rows private by default.
- Preserve the existing owner assignment and visibility API.

## Compatibility

Existing explicit public/shared/private mappings are unchanged. Only previously untracked collections now default to private.

## Tests

- `python -m compileall -q ui/backend`
- `git diff --check`

## Not run / limitations

The repository does not contain a focused UI backend test suite in the checked-out tree. Full dependency-based CI is left to GitHub Actions.
