### PR TITLE
fix: preload FAISS selectively on Windows

### DIFF
--- a/servers/retriever/src/retriever.py
+++ b/servers/retriever/src/retriever.py
@@ -1273,5 +1273,12 @@ class Retriever:
 
 
 if __name__ == "__main__":
+    if os.name == "nt" and os.environ.get("ULTRARAG_PRELOAD_FAISS") == "1":
+        try:
+            # Load FAISS before FastMCP starts its event loop on Windows.
+            import faiss  # noqa: F401
+        except ImportError:
+            pass
+
     Retriever(app)
     app.run(transport="stdio")

--- a/src/ultrarag/client.py
+++ b/src/ultrarag/client.py
@@ -2107,6 +2107,19 @@ async def run(
     log_server_banner(Path(config_path).stem)
 
     context = load_pipeline_context(config_path, param_path)
+    if os.name == "nt":
+        for name, server_config in context["server_cfg"].items():
+            mcp_server = context["mcp_cfg"]["mcpServers"].get(name)
+            if not isinstance(mcp_server, dict):
+                continue
+            mcp_server["env"].pop("ULTRARAG_PRELOAD_FAISS", None)
+            server_params = server_config.get("parameter", {})
+            if (
+                not is_demo
+                and isinstance(server_params, dict)
+                and str(server_params.get("index_backend", "")).lower() == "faiss"
+            ):
+                mcp_server["env"]["ULTRARAG_PRELOAD_FAISS"] = "1"
 
     client = create_mcp_client(context["mcp_cfg"])
 


### PR DESCRIPTION
## Summary

- preload FAISS before FastMCP starts on Windows to avoid the native OpenMP/BLAS loading hang
- enable the preload only for non-demo pipelines configured with `index_backend: faiss`
- leave demo, non-FAISS, macOS, and Linux startup behavior unchanged

## Validation

- `ultrarag build <pipeline>` — passed
- non-demo FAISS `ultrarag run <pipeline> --param <parameter>` — passed with `faiss-cpu 1.15.0`; indexed 4 test vectors
- non-demo Milvus pipeline with a fail-on-import fake FAISS module — passed, confirming FAISS was not imported
- demo pipeline with FAISS in the parameter file but Milvus forced at runtime — passed, confirming FAISS was not imported
- targeted Ruff checks, `compileall`, `pip check`, and `git diff --check` — passed

## Why

On Windows, importing some FAISS builds for the first time after FastMCP has started its stdio event loop can hang the retriever process. Importing FAISS before server startup avoids the hang, but doing so for every retriever pipeline would affect users of other index backends. The client therefore passes a one-process environment flag only for the affected non-demo FAISS pipeline.