### PR TITLE
fix(evaluation): keep answers that are entirely articles

### DIFF
--- a/servers/evaluation/src/evaluation.py
+++ b/servers/evaluation/src/evaluation.py
@@ -35,7 +35,13 @@ def normalize_text(text: str) -> str:
         return {"True": "yes", "False": "no"}.get(s, s)
 
     def _remove_articles(t: str) -> str:
-        return re.sub(r"\b(a|an|the)\b", " ", t)
+        # Article stripping must not consume the whole answer. A multiple-choice
+        # gold of "A" (prompt/qa_boxed_multiple_choice labels options with
+        # string.ascii_uppercase) normalizes to "" otherwise, and an empty
+        # string is a substring of every prediction, so acc and coverem score
+        # 1.0 against any answer. Keep the un-stripped form in that case.
+        stripped = re.sub(r"\b(a|an|the)\b", " ", t)
+        return t if not stripped.strip() else stripped
 
     def _white_space_fix(t: str) -> str:
         return " ".join(t.split())

--- a/tests/servers/evaluation/test_normalize_text.py
+++ b/tests/servers/evaluation/test_normalize_text.py
@@ -1,0 +1,86 @@
+"""Tests for evaluation-metric normalization in the ``evaluation`` MCP server.
+
+The ``evaluation`` server lives under ``servers/evaluation/src`` rather than
+inside the installable ``ultrarag`` package. Importing the module directly would
+pull in the MCP app and the rouge scorer, so the pure functions under test are
+lifted out of the source with ``ast`` instead.
+"""
+
+import ast
+import re
+import string
+from pathlib import Path
+from typing import List
+
+EVALUATION_SRC = (
+    Path(__file__).resolve().parents[3] / "servers" / "evaluation" / "src" / "evaluation.py"
+)
+
+_WANTED = {
+    "normalize_text",
+    "accuracy_score",
+    "exact_match_score",
+    "cover_exact_match_score",
+}
+
+
+def _load():
+    tree = ast.parse(EVALUATION_SRC.read_text())
+    module = ast.Module(
+        body=[
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name in _WANTED
+        ],
+        type_ignores=[],
+    )
+    namespace = {"re": re, "string": string, "List": List}
+    exec(compile(module, str(EVALUATION_SRC), "exec"), namespace)
+    return namespace
+
+
+_NS = _load()
+normalize_text = _NS["normalize_text"]
+accuracy_score = _NS["accuracy_score"]
+exact_match_score = _NS["exact_match_score"]
+cover_exact_match_score = _NS["cover_exact_match_score"]
+
+
+def test_single_letter_answer_survives_normalization():
+    # qa_boxed_multiple_choice labels options with string.ascii_uppercase, so
+    # "A" is a real gold value. Stripping it to "" makes it match everything.
+    assert normalize_text("A") == "a"
+
+
+def test_article_only_answer_survives_normalization():
+    assert normalize_text("the") == "the"
+
+
+def test_accuracy_rejects_a_wrong_multiple_choice_answer():
+    assert accuracy_score(["A"], "D") == 0.0
+
+
+def test_accuracy_accepts_a_correct_multiple_choice_answer():
+    assert accuracy_score(["A"], "A") == 1.0
+
+
+def test_cover_exact_match_rejects_a_wrong_multiple_choice_answer():
+    assert cover_exact_match_score(["A"], "D") == 0.0
+
+
+def test_cover_exact_match_accepts_a_correct_multiple_choice_answer():
+    # Regression guard: passes with and without the fix, because an empty
+    # token list also matched. It pins the behaviour the fix must not break.
+    assert cover_exact_match_score(["A"], "A") == 1.0
+
+
+def test_articles_are_still_stripped_inside_a_longer_answer():
+    # Regression guard: passes with and without the fix.
+    assert normalize_text("The Beatles") == "beatles"
+    assert accuracy_score(["the beatles"], "Beatles") == 1.0
+
+
+def test_unaffected_option_letters_are_unchanged():
+    # Regression guard: passes with and without the fix.
+    assert accuracy_score(["B"], "D") == 0.0
+    assert accuracy_score(["B"], "B") == 1.0


### PR DESCRIPTION
Fixes #509.

`normalize_text` stripped articles unconditionally, so a gold answer of `"A"` normalized to the empty string. An empty string is a substring of every prediction, so `accuracy_score` returned 1.0 whatever the model answered, and `cover_exact_match_score` did the same because `all()` over an empty token list is `True`. The same gold scored 0.0 when the model was right, because `accuracy_score` returns early on an empty normalized prediction.

Both metrics are in the default set (`servers/evaluation/parameter.yaml:5`), and `qa_boxed_multiple_choice` labels options with `string.ascii_uppercase`, so a run of `examples/experiments/vanilla_multiple_choice.yaml` reported inflated `acc` and `coverem` on every question whose answer was A.

## The change

Article removal now keeps the un-stripped form when it would otherwise leave nothing:

```python
stripped = re.sub(r"\b(a|an|the)\b", " ", t)
return t if not stripped.strip() else stripped
```

`"The Beatles"` still normalizes to `"beatles"`. Only the case where the whole string would disappear behaves differently.

I tried guarding inside the metrics first, skipping golds that normalize to empty. That scores a correct `"A"` as 0.0, so it trades a false positive for a false negative. The normalization is the right place.

## Tests

`tests/servers/evaluation/test_normalize_text.py`, 8 tests. The evaluation server is not part of the installable package and importing it pulls in the MCP app and the rouge scorer, so the pure functions are lifted out with `ast`, matching how `tests/servers/custom/test_query_extract.py` reaches into `servers/custom/src`.

Five fail on current `main` and are reproductions:

- `test_single_letter_answer_survives_normalization`
- `test_article_only_answer_survives_normalization`
- `test_accuracy_rejects_a_wrong_multiple_choice_answer`
- `test_accuracy_accepts_a_correct_multiple_choice_answer`
- `test_cover_exact_match_rejects_a_wrong_multiple_choice_answer`

Three pass with and without the change and are regression guards, labelled as such in the file:

- `test_cover_exact_match_accepts_a_correct_multiple_choice_answer`
- `test_articles_are_still_stripped_inside_a_longer_answer`
- `test_unaffected_option_letters_are_unchanged`

`pytest tests/` is 12 passed.

One thing I did not change: `exact_match_score` and `string_em_score` compare normalized strings for equality, so an empty gold only matched an empty prediction and they were never wrong here. They pick up the corrected normalization for free.